### PR TITLE
chore/replacing jcenter

### DIFF
--- a/in_app_review/CHANGELOG.md
+++ b/in_app_review/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [2.0.4]
 
-- Migrate from jcenter to mavenCentral
+- Migrate maven repository from jcenter to mavenCentral
 # [2.0.3]
 
 - Fix iOS no-scene exception. ([#41](https://github.com/britannio/in_app_review/issues/41))

--- a/in_app_review/CHANGELOG.md
+++ b/in_app_review/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [2.0.4]
+
+- Migrate from jcenter to mavenCentral
 # [2.0.3]
 
 - Fix iOS no-scene exception. ([#41](https://github.com/britannio/in_app_review/issues/41))

--- a/in_app_review/android/build.gradle
+++ b/in_app_review/android/build.gradle
@@ -4,7 +4,7 @@ version '1.0'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -15,7 +15,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/in_app_review/example/android/build.gradle
+++ b/in_app_review/example/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -12,7 +12,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/in_app_review/pubspec.yaml
+++ b/in_app_review/pubspec.yaml
@@ -1,6 +1,6 @@
 name: in_app_review
 description: Flutter plugin for showing the In-App Review/System Rating pop up on Android, IOS and MacOS. It makes it easy for users to rate your app.
-version: 2.0.3
+version: 2.0.4
 homepage: https://github.com/britannio/in_app_review/tree/master/in_app_review
 
 environment:


### PR DESCRIPTION
Considering jcenter will shut down soon, it is suggested to migrate from jcenter repository to mavenCentral.
Flutter packages are already migrated to it > flutter/flutter#82847