### PR TITLE
Upgrade android min SDK and compile SDK

### DIFF
--- a/in_app_review/android/build.gradle
+++ b/in_app_review/android/build.gradle
@@ -30,7 +30,7 @@ android {
       namespace 'dev.britannio.in_app_review'
     }
 
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -46,14 +46,12 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
     }
     dependencies {
         // Release notes: https://developer.android.com/reference/com/google/android/play/core/release-notes-in_app_reviews
         implementation 'com.google.android.play:review:2.0.2'
         // Release notes: https://developers.google.com/android/guides/releases
-        implementation 'com.google.android.gms:play-services-base:18.2.0'
-
-
+        implementation 'com.google.android.gms:play-services-base:18.5.0'
     }
 }

--- a/in_app_review/pubspec.yaml
+++ b/in_app_review/pubspec.yaml
@@ -1,6 +1,6 @@
 name: in_app_review
 description: Flutter plugin for showing the In-App Review/System Rating pop up on Android, iOS and MacOS. It makes it easy for users to rate your app.
-version: 2.0.10
+version: 2.0.11
 homepage: https://github.com/britannio/in_app_review/tree/master/in_app_review
 repository: https://github.com/britannio/in_app_review
 issue_tracker: https://github.com/britannio/in_app_review/issues


### PR DESCRIPTION
android minSdk compatible with flutter is 21
[Flutter supported platforms](https://docs.flutter.dev/reference/supported-platforms)