### PR TITLE
Fixes for activity in android

### DIFF
--- a/in_app_review/CHANGELOG.md
+++ b/in_app_review/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [2.0.12]
+
+- Fix Android NPE crash when Activity is detached during async review request
+
 # [2.0.11]
 
 - Regenerate the plugin & migrate Android platform code from Java to Kotlin

--- a/in_app_review/pubspec.yaml
+++ b/in_app_review/pubspec.yaml
@@ -1,6 +1,6 @@
 name: in_app_review
 description: Flutter plugin for showing the In-App Review/System Rating pop up on Android, iOS and MacOS. It makes it easy for users to rate your app.
-version: 2.0.11
+version: 2.0.12
 homepage: https://github.com/britannio/in_app_review/tree/master/in_app_review
 repository: https://github.com/britannio/in_app_review
 issue_tracker: https://github.com/britannio/in_app_review/issues


### PR DESCRIPTION
## Fix: NPE crash in requestReview() due to race condition

### Issue
`NullPointerException` when Activity is detached during async review request:

Exception java.lang.NullPointerException:
at dev.britannio.in_app_review.InAppReviewPlugin.requestReview$lambda$2 (InAppReviewPlugin.java:106)
at com.google.android.gms.tasks.zzi.run (zzi.java:1)
at android.os.Handler.handleCallback (Handler.java:938)
at android.os.Handler.dispatchMessage (Handler.java:99)
at android.os.Looper.loopOnce (Looper.java:226)
at android.os.Looper.loop (Looper.java:313)
at android.app.ActivityThread.main (ActivityThread.java:8663)


### Root Cause
Race condition between initial null check and async callback execution. If user backgrounds the app after `requestReviewFlow()` starts but before `launchReviewFlow()` executes, `activity` becomes null, causing NPE.

### Solution
- Capture local references to `context`/`activity` before async operations
- Re-check activity availability in async callback before using it
- Refactor to use single `getContextAndActivity()` helper method
- Return proper error to Flutter instead of crashing

### Changes
- Added `getContextAndActivity()` to eliminate code duplication
- Removed redundant `noContextOrActivity()` method
- All methods now safely handle activity lifecycle changes