### PR TITLE
[in_app_review] Support AGP 9 via built-in Kotlin

### DIFF
--- a/in_app_review/CHANGELOG.md
+++ b/in_app_review/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [2.0.13]
+
+- Migrate the Android build to built-in Kotlin for Android Gradle Plugin (AGP) 9+ compatibility.
+- Apply the Kotlin Gradle Plugin (KGP) only when the Android Gradle Plugin version is below 9.
+- Bump the Android compileSdkVersion to 36.
+
 # [2.0.12]
 
 - Fix an Android NullPointerException that sometimes occurred when apps were backgrounded.

--- a/in_app_review/android/build.gradle
+++ b/in_app_review/android/build.gradle
@@ -2,14 +2,14 @@ group = "dev.britannio.in_app_review"
 version = "1.0-SNAPSHOT"
 
 buildscript {
-    ext.kotlin_version = "2.1.0"
+    ext.kotlin_version = "2.2.0"
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.7.3")
+        classpath("com.android.tools.build:gradle:8.12.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }
@@ -22,20 +22,20 @@ allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: "kotlin-android"
+}
 
 android {
     namespace = "dev.britannio.in_app_review"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
     }
 
     sourceSets {
@@ -67,5 +67,11 @@ android {
                showStandardStreams = true
             }
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
 }

--- a/in_app_review/android/build.gradle
+++ b/in_app_review/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: "com.android.library"
 
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
 if (agpMajor < 9) {
-    apply plugin: "kotlin-android"
+    pluginManager.apply("kotlin-android")
 }
 
 android {

--- a/in_app_review/example/android/app/build.gradle.kts
+++ b/in_app_review/example/android/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.application")
-    id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }
@@ -13,10 +12,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
     defaultConfig {
@@ -36,6 +31,12 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.getByName("debug")
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
 }
 

--- a/in_app_review/example/android/gradle.properties
+++ b/in_app_review/example/android/gradle.properties
@@ -1,3 +1,6 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-android.enableJetifier=true
+# Enable AGP 9's built-in Kotlin support.
+android.builtInKotlin=true
+# Keep using the legacy AGP DSL for now.
+android.newDsl=false

--- a/in_app_review/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/in_app_review/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/in_app_review/example/android/settings.gradle.kts
+++ b/in_app_review/example/android/settings.gradle.kts
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.7.3" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    id("com.android.application") version "9.1.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.4.0" apply false
 }
 
 include(":app")

--- a/in_app_review/pubspec.yaml
+++ b/in_app_review/pubspec.yaml
@@ -1,6 +1,6 @@
 name: in_app_review
 description: Flutter plugin for showing the In-App Review/System Rating pop up on Android, iOS and MacOS. It makes it easy for users to rate your app.
-version: 2.0.12
+version: 2.0.13
 homepage: https://github.com/britannio/in_app_review/tree/master/in_app_review
 repository: https://github.com/britannio/in_app_review
 issue_tracker: https://github.com/britannio/in_app_review/issues


### PR DESCRIPTION
- Migrates the Android build to AGP 9's built-in Kotlin for AGP 9+ compatibility.

- Applies the Kotlin Gradle Plugin (`kotlin-android`) only when the Android Gradle Plugin version is below 9, keeping full backward compatibility with AGP 8.

- Replaces the deprecated `kotlinOptions` block with `kotlin { compilerOptions { ... } }`.

- Bumps `compileSdk` to 36 and updates the example app to AGP 9.1.0 / Gradle 9.3.1 with `android.builtInKotlin=true`.

- Closes #184 and #185.
